### PR TITLE
Add notes for TSC Meeting on September 9, 2025

### DIFF
--- a/meetings/notes/joint-meeting-20250909.md
+++ b/meetings/notes/joint-meeting-20250909.md
@@ -1,0 +1,45 @@
+# TSC Meeting - 9/09/2025
+
+## Chair and Co-Chair
+* Nick_L
+* Tobias Alexander Franke [Huawei]
+
+## Attendees (By Discord name)
+* Hellaenergy (Nick) [Red Hat]
+* Jan Hanca [Robotec.ai]
+* jayrulez
+* Joe Bryant [O3DF]
+* JT [SCB_GameDesign]
+* Matteo [Loharangrin]
+* null
+* Reece H. [DrogonMar]
+* Sid_Moudgil [Amzn]
+* Steve P [Amazon]
+* colinb [APMG]
+
+## Meeting Notes
+
+### Announcement - Joe - AMA September 10 wednesday coming up
+* Send complicated topics ahead of time, so that Joe can do research.
+* Please spread the word to everyone and anyone.  it will be recorded.
+
+### Anouncement - Mike - Github AR progress
+* github AR progress is getting close, we need a formal a plan for switch over
+* should cover the switch over, decomissioning of the jenkins fleet
+* Joe: We should time to be after the release
+* Some blockers still remain: Gradle problems for Android: suggestion to go to latest, could break, but its already broken.
+
+### Discussion - Current State of Particle System
+* Working
+* Joe: Do we have a project for this?
+* JT: I beleive the PR has a level.
+* Colin: Not sure it does.
+* Joe: We need a level to showcase the particle system
+* Colin: We could use the lumberyard paricle showcase level, the one we used for PopcornFX?
+* Joe: Sid, do you have access to that?
+* Sid: Its been a long time... but should be just a simple level. We could potentially make a new one, or modify an existing one. Atom viewer may have something. MPS used PopcornFX, it was always breaking, we could update MPS but that is a big ask.
+* Null: Yeah the FX in MPS was breaking a lot and updating it would be a lift.
+* Joe: We need something, we should ask the community. Do we have any pictures or videos for docs and promotion?
+* Jan: I posted some quick captures in the chat.
+  
+


### PR DESCRIPTION
Documented the TSC meeting held on September 9, 2025, including attendees and key discussion points.